### PR TITLE
Add landing page setup

### DIFF
--- a/instalador/install_instancia
+++ b/instalador/install_instancia
@@ -67,6 +67,13 @@ frontend_node_build
 frontend_start_pm2
 frontend_nginx_setup
 
+# landing related
+landing_set_env
+landing_node_dependencies
+landing_node_build
+landing_start_pm2
+landing_nginx_setup
+
 # network related
 #system_nginx_conf
 system_nginx_restart

--- a/instalador/install_primaria
+++ b/instalador/install_primaria
@@ -67,6 +67,13 @@ frontend_node_build
 frontend_start_pm2
 frontend_nginx_setup
 
+# landing related
+landing_set_env
+landing_node_dependencies
+landing_node_build
+landing_start_pm2
+landing_nginx_setup
+
 # network related
 system_nginx_conf
 system_nginx_restart

--- a/instalador/lib/_inquiry.sh
+++ b/instalador/lib/_inquiry.sh
@@ -73,6 +73,22 @@ get_backend_port() {
   read -p "> " backend_port
 }
 
+get_landing_url() {
+
+  print_banner
+  printf "${WHITE} 💻 Digite o domínio do LANDING PAGE para a ${instancia_add}:${GRAY_LIGHT}"
+  printf "\n\n"
+  read -p "> " landing_url
+}
+
+get_landing_port() {
+
+  print_banner
+  printf "${WHITE} 💻 Digite a porta do LANDING PAGE para a ${instancia_add}; Ex: 6000 A 6999 ${GRAY_LIGHT}"
+  printf "\n\n"
+  read -p "> " landing_port
+}
+
 get_redis_port() {
   
   print_banner
@@ -166,12 +182,15 @@ get_urls() {
   get_frontend_port
   get_backend_port
   get_redis_port
+  get_landing_url
+  get_landing_port
 }
 
 software_update() {
   get_empresa_atualizar
   frontend_update
   backend_update
+  landing_update
 }
 
 software_delete() {

--- a/instalador/lib/_landing.sh
+++ b/instalador/lib/_landing.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# functions for setting up landing page
+
+#######################################
+# installed node packages
+# Arguments:
+#   None
+#######################################
+landing_node_dependencies() {
+  print_banner
+  printf "${WHITE} 💻 Instalando dependências do landing...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  sudo su - deploy <<EOF2
+  cd /home/deploy/${instancia_add}/landing
+  npm install
+EOF2
+
+  sleep 2
+}
+
+#######################################
+# compiles landing code
+# Arguments:
+#   None
+#######################################
+landing_node_build() {
+  print_banner
+  printf "${WHITE} 💻 Compilando o código do landing...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  sudo su - deploy <<EOF2
+  cd /home/deploy/${instancia_add}/landing
+  npm run build
+EOF2
+
+  sleep 2
+}
+
+#######################################
+# updates landing code
+# Arguments:
+#   None
+#######################################
+landing_update() {
+  print_banner
+  printf "${WHITE} 💻 Atualizando o landing...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  sudo su - deploy <<EOF2
+  cd /home/deploy/${empresa_atualizar}
+  pm2 stop ${empresa_atualizar}-landing
+  git pull
+  cd /home/deploy/${empresa_atualizar}/landing
+  npm install
+  rm -rf build
+  npm run build
+  pm2 start ${empresa_atualizar}-landing
+  pm2 save
+EOF2
+
+  sleep 2
+}
+
+#######################################
+# sets landing environment variables
+# Arguments:
+#   None
+#######################################
+landing_set_env() {
+  print_banner
+  printf "${WHITE} 💻 Configurando variáveis de ambiente (landing)...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  sudo su - deploy << EOF2
+  cat <<[-]EOF3 > /home/deploy/${instancia_add}/landing/.env
+REACT_APP_BACKEND_URL=${backend_url}
+[-]EOF3
+EOF2
+
+  sleep 2
+
+  sudo su - deploy << EOF2
+  cat <<[-]EOF3 > /home/deploy/${instancia_add}/landing/server.js
+const express = require("express");
+const path = require("path");
+const app = express();
+app.use(express.static(path.join(__dirname, "build")));
+app.get("/*", function (req, res) {
+        res.sendFile(path.join(__dirname, "build", "index.html"));
+});
+app.listen(${landing_port});
+[-]EOF3
+EOF2
+
+  sleep 2
+}
+
+#######################################
+# starts pm2 for landing
+# Arguments:
+#   None
+#######################################
+landing_start_pm2() {
+  print_banner
+  printf "${WHITE} 💻 Iniciando pm2 (landing)...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  sudo su - deploy <<EOF2
+  cd /home/deploy/${instancia_add}/landing
+  pm2 start server.js --name ${instancia_add}-landing
+  pm2 save
+EOF2
+
+ sleep 2
+
+  sudo su - root <<EOF2
+   pm2 startup
+  sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u deploy --hp /home/deploy
+EOF2
+  sleep 2
+}
+
+#######################################
+# sets up nginx for landing
+# Arguments:
+#   None
+#######################################
+landing_nginx_setup() {
+  print_banner
+  printf "${WHITE} 💻 Configurando nginx (landing)...${GRAY_LIGHT}"
+  printf "\n\n"
+
+  sleep 2
+
+  landing_hostname=$(echo "${landing_url/https:\/\/}")
+
+sudo su - root << EOF2
+
+cat > /etc/nginx/sites-available/${instancia_add}-landing << 'END'
+server {
+  server_name $landing_hostname;
+
+  location / {
+    proxy_pass http://127.0.0.1:${landing_port};
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_cache_bypass \$http_upgrade;
+  }
+}
+END
+
+ln -s /etc/nginx/sites-available/${instancia_add}-landing /etc/nginx/sites-enabled
+EOF2
+
+  sleep 2
+}

--- a/instalador/lib/_system.sh
+++ b/instalador/lib/_system.sh
@@ -79,9 +79,11 @@ deletar_tudo() {
   sudo su - root <<EOF
   docker container rm redis-${empresa_delete} --force
   cd && rm -rf /etc/nginx/sites-enabled/${empresa_delete}-frontend
-  cd && rm -rf /etc/nginx/sites-enabled/${empresa_delete}-backend  
+  cd && rm -rf /etc/nginx/sites-enabled/${empresa_delete}-backend
+  cd && rm -rf /etc/nginx/sites-enabled/${empresa_delete}-landing
   cd && rm -rf /etc/nginx/sites-available/${empresa_delete}-frontend
   cd && rm -rf /etc/nginx/sites-available/${empresa_delete}-backend
+  cd && rm -rf /etc/nginx/sites-available/${empresa_delete}-landing
   
   sleep 2
 
@@ -95,7 +97,7 @@ sleep 2
 
 sudo su - deploy <<EOF
  rm -rf /home/deploy/${empresa_delete}
- pm2 delete ${empresa_delete}-frontend ${empresa_delete}-backend
+ pm2 delete ${empresa_delete}-frontend ${empresa_delete}-backend ${empresa_delete}-landing
  pm2 save
 EOF
 
@@ -250,13 +252,14 @@ EOF
 
   backend_domain=$(echo "${backend_url/https:\/\/}")
   frontend_domain=$(echo "${frontend_url/https:\/\/}")
+  landing_domain=$(echo "${landing_url/https:\/\/}")
 
   sudo su - root <<EOF
   certbot -m $deploy_email \
           --nginx \
           --agree-tos \
           --non-interactive \
-          --domains $backend_domain,$frontend_domain
+          --domains $backend_domain,$frontend_domain,$landing_domain
 EOF
 
   sleep 2

--- a/instalador/lib/manifest.sh
+++ b/instalador/lib/manifest.sh
@@ -2,5 +2,6 @@
 
 source "${PROJECT_ROOT}"/lib/_backend.sh
 source "${PROJECT_ROOT}"/lib/_frontend.sh
+source "${PROJECT_ROOT}"/lib/_landing.sh
 source "${PROJECT_ROOT}"/lib/_system.sh
 source "${PROJECT_ROOT}"/lib/_inquiry.sh


### PR DESCRIPTION
## Summary
- add landing page support to installer scripts
- define landing page setup steps
- prompt user for landing URL and port
- include landing page when managing instances

## Testing
- `shellcheck instalador/lib/_landing.sh`
- `shellcheck instalador/lib/_inquiry.sh`
- `shellcheck instalador/lib/_system.sh`
- `shellcheck instalador/install_primaria instalador/install_instancia`


------
https://chatgpt.com/codex/tasks/task_e_684efcbdf4788327996c335a0bc3ff60