### PR TITLE
Remove netifaces dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 scapy
-netifaces


### PR DESCRIPTION
## Summary
- use a pure Python approach to detect network parameters
- remove netifaces from imports and from requirements

## Testing
- `python3 -m py_compile wifikill.py`

------
https://chatgpt.com/codex/tasks/task_e_687c5d53028c8327bef81ff99ac1f580