### PR TITLE
Improve bot loop and dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,26 +1,32 @@
-import time
+import keyboard
 from modules.attack import attack
 from modules.loot import loot
-import keyboard
 
-def main():
-    print("🔁 Bot iniciado. Pressione F8 para parar.")
-    running = True
 
-    # Pressione F8 para parar
-    keyboard.add_hotkey('F8', lambda: stop())
+RUNNING = True
 
-    while True:
-        try:
-            attack()
-            loot()
-        except Exception as e:
-            print(f"Erro: {e}")
-            break
 
 def stop():
-    print("🛑 Bot parado.")
-    exit()
+    """Stop the bot loop."""
+    global RUNNING
+    RUNNING = False
+
+
+def main():
+    """Start the attack/loot loop until F8 is pressed."""
+    print("🔁 Bot iniciado. Pressione F8 para parar.")
+
+    keyboard.add_hotkey("F8", stop)
+
+    try:
+        while RUNNING:
+            attack()
+            loot()
+    except Exception as e:
+        print(f"Erro: {e}")
+    finally:
+        print("🛑 Bot parado.")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/attack.py
+++ b/modules/attack.py
@@ -1,7 +1,10 @@
 import pyautogui
 import time
+
 from config import ATTACK_KEY, ATTACK_DELAY
 
+
 def attack():
+    """Trigger the attack key and wait for the delay."""
     pyautogui.press(ATTACK_KEY)
     time.sleep(ATTACK_DELAY)

--- a/modules/loot.py
+++ b/modules/loot.py
@@ -1,7 +1,10 @@
 import pyautogui
 import time
+
 from config import LOOT_KEY, LOOT_DELAY
 
+
 def loot():
+    """Press the loot key and wait for the delay."""
     pyautogui.press(LOOT_KEY)
     time.sleep(LOOT_DELAY)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pyautogui
 keyboard
-time
 mss
 opencv-python
 pytesseract


### PR DESCRIPTION
## Summary
- adjust main loop with stoppable `RUNNING` flag
- add docstrings and spacing for PEP8 compliance
- clean up requirements

## Testing
- `flake8`
- `python -m py_compile main.py modules/attack.py modules/loot.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687f1029856c8327bb991d19ee5aabbc