### PR TITLE
Improve key actions using pydirectinput

### DIFF
--- a/modules/attack.py
+++ b/modules/attack.py
@@ -1,10 +1,13 @@
-import keyboard
 import time
+try:
+    import pydirectinput
+except ImportError:  # fallback if pydirectinput is missing
+    import pyautogui as pydirectinput
 
 from config import ATTACK_KEY, ATTACK_DELAY
 
 
 def attack():
     """Trigger the attack key and wait for the delay."""
-    keyboard.press_and_release(ATTACK_KEY)
+    pydirectinput.press(ATTACK_KEY)
     time.sleep(ATTACK_DELAY)

--- a/modules/loot.py
+++ b/modules/loot.py
@@ -1,10 +1,13 @@
-import keyboard
 import time
+try:
+    import pydirectinput
+except ImportError:  # fallback if pydirectinput is missing
+    import pyautogui as pydirectinput
 
 from config import LOOT_KEY, LOOT_DELAY
 
 
 def loot():
     """Press the loot key and wait for the delay."""
-    keyboard.press_and_release(LOOT_KEY)
+    pydirectinput.press(LOOT_KEY)
     time.sleep(LOOT_DELAY)

--- a/modules/move.py
+++ b/modules/move.py
@@ -1,13 +1,16 @@
 # modules/move.py
-import keyboard
 import random
 import time
+try:
+    import pydirectinput
+except ImportError:  # fallback if pydirectinput is missing
+    import pyautogui as pydirectinput
 from config import MOVE_KEYS
 
 def move():
     key = random.choice(MOVE_KEYS)
     duration = random.uniform(0.2, 0.4)
-    keyboard.press(key)
+    pydirectinput.keyDown(key)
     time.sleep(duration)
-    keyboard.release(key)
+    pydirectinput.keyUp(key)
     time.sleep(0.4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mss
 opencv-python
 pytesseract
 numpy
+pydirectinput


### PR DESCRIPTION
## Summary
- use `pydirectinput` to send key presses recognized by games
- fallback to `pyautogui` if `pydirectinput` isn't available
- add `pydirectinput` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1faeb4c883278225d84abc8cb71e